### PR TITLE
JavaScript相互運用の整理。

### DIFF
--- a/src/Interop.fs
+++ b/src/Interop.fs
@@ -8,26 +8,6 @@ open App.Types
 open App.JsUtils
 open App.Plugins
 
-// JavaScriptのプレーンオブジェクトをF#のMapに変換
-let plainJsObjToMap (jsObj: obj) : Map<string, obj> =
-    if isNullOrUndefined jsObj then
-        Map.empty<string, obj>
-    else
-        try
-            let keys = Fable.Core.JS.Constructors.Object.keys (jsObj)
-            let mutable map = Map.empty<string, obj>
-
-            for key in keys do
-                let value = jsObj?(key)
-
-                if not (isUndefined value) then
-                    map <- map.Add(key, value)
-
-            map
-        with ex ->
-            printfn "Error converting JS object to Map: %s" ex.Message
-            Map.empty<string, obj>
-
 // F#のモデルをJavaScriptフレンドリーな形式に変換
 let convertModelToJS (model: Model) : obj =
     let jsObj = createEmptyJsObj ()

--- a/src/JsUtils.fs
+++ b/src/JsUtils.fs
@@ -5,6 +5,8 @@ module App.JsUtils
 open Fable.Core
 open Fable.Core.JsInterop
 
+// ========== 基本的なJavaScript型操作 ==========
+
 // 空のJavaScriptオブジェクトを作成する関数
 [<Emit("{}")>]
 let createEmptyJsObj () : obj = jsNative
@@ -29,6 +31,8 @@ let jsTypeof (obj: obj) : string = jsNative
 [<Emit("typeof $0 === 'function'")>]
 let isJsFunction (obj: obj) : bool = jsNative
 
+// ========== JSON操作 ==========
+
 // JSON文字列に変換
 [<Emit("JSON.stringify($0, null, 2)")>]
 let jsonStringify (obj: obj) : string = jsNative
@@ -36,6 +40,8 @@ let jsonStringify (obj: obj) : string = jsNative
 // JSON文字列からオブジェクトに戻す
 [<Emit("JSON.parse($0)")>]
 let jsonParse (str: string) : obj = jsNative
+
+// ========== オブジェクト操作 ==========
 
 // オブジェクトのプロパティをセーフにアクセスする
 [<Emit("$0 && $0[$1]")>]
@@ -48,6 +54,112 @@ let mapToPlainJsObj (map: Map<string, obj>) : obj = jsNative
 // JavaScript関数を直接呼び出し、引数を渡す
 [<Emit("$0($1)")>]
 let callJsFunction (func: obj) (args: obj) : obj = jsNative
+
+// ========== ファイル/ネットワーク操作 ==========
+
+// プラグイン設定を外部JSONから読み込む
+[<Emit("fetch($0).then(r => r.json())")>]
+let fetchJson (url: string) : JS.Promise<obj> = jsNative
+
+// 動的スクリプト読み込み - 重複読み込み防止バージョン＋デバッグ強化
+[<Emit("""
+new Promise((resolve, reject) => { 
+    const selector = `script[src='${$0}']`;
+    if (document.querySelector(selector)) { 
+        console.log('Script already loaded: ' + $0); 
+        resolve(); 
+        return; 
+    } 
+    const script = document.createElement('script'); 
+    script.src = $0; 
+    
+    script.onload = () => {
+        console.log('Successfully loaded script: ' + $0);
+        resolve();
+    }; 
+    
+    script.onerror = (error) => {
+        console.error('Failed to load script: ' + $0, error);
+        reject(new Error('Failed to load script: ' + $0));
+    }; 
+    
+    document.head.appendChild(script);
+    console.log('Appended script to head: ' + $0);
+})
+""")>]
+let loadScript (url: string) : JS.Promise<unit> = jsNative
+
+// HTMLからプラグインスクリプトを自動的に読み込む
+[<Emit("""
+new Promise((resolve, reject) => {
+    try {
+        const pluginScripts = document.querySelectorAll('script[type="plugin"]');
+        console.log('Found ' + pluginScripts.length + ' plugin scripts');
+        
+        if (pluginScripts.length === 0) {
+            resolve();
+            return;
+        }
+        
+        const promises = [];
+        
+        for (const script of pluginScripts) {
+            const src = script.getAttribute('src');
+            if (src) {
+                console.log('Loading plugin script: ' + src);
+                promises.push(new Promise((innerResolve, innerReject) => {
+                    const scriptEl = document.createElement('script');
+                    scriptEl.src = src;
+                    scriptEl.onload = innerResolve;
+                    scriptEl.onerror = innerReject;
+                    document.head.appendChild(scriptEl);
+                }));
+            }
+        }
+        
+        Promise.all(promises).then(resolve).catch(reject);
+    } catch (error) {
+        console.error('Error loading plugin scripts:', error);
+        reject(error);
+    }
+})
+""")>]
+let loadPluginScriptTags () : JS.Promise<unit> = jsNative
+
+// ========== プラグイン関連 ==========
+
+// F#側のプラグインディスパッチ関数をグローバルに公開
+[<Emit("window.appPluginDispatch = $0")>]
+let exposePluginDispatch (dispatch: obj -> unit) : unit = jsNative
+
+// Store the registerPluginFromJs function directly in a global variable
+[<Emit("window._fsharpRegisterPluginFn = $0")>]
+let storeRegisterPluginFunction (fn: obj -> (App.Types.Msg -> unit) option -> bool) : unit = jsNative
+
+// Set up the global registration function that will call our stored function
+[<Emit("""
+window.registerFSharpPlugin = function(plugin) {
+    try {
+        return window._fsharpRegisterPluginFn(plugin);
+    } catch (error) {
+        console.error("Error registering plugin:", error);
+        return false;
+    }
+}
+""")>]
+let setupGlobalRegistration () : unit = jsNative
+
+// グローバルなJavaScriptブリッジ関数を使用して更新関数を呼び出す
+[<Emit("window.FSharpJsBridge.callUpdateHandler($0, $1, $2)")>]
+let callUpdateHandlerViaJsBridge (updateFn: obj) (payload: obj) (model: obj) : obj = jsNative
+
+// 統合されたupdate関数を呼び出す
+[<Emit("window.FSharpJsBridge.callUnifiedUpdateHandler($0, $1, $2, $3)")>]
+let callUnifiedUpdateHandler (updateFn: obj) (messageType: string) (payload: obj) (model: obj) : obj = jsNative
+
+// デバッグ用のオブジェクトロギング関数
+[<Emit("window.FSharpJsBridge.logObject($0, $1)")>]
+let logObjectViaJsBridge (label: string) (obj: obj) : obj = jsNative
 
 // JavaScriptのプレーンオブジェクトをF#のMapに変換
 let plainJsObjToMap (jsObj: obj) : Map<string, obj> =

--- a/src/PluginLoader.fs
+++ b/src/PluginLoader.fs
@@ -3,75 +3,7 @@ module App.PluginLoader
 
 open Fable.Core
 open Fable.Core.JsInterop
-
-// プラグイン設定を外部JSONから読み込む
-[<Emit("fetch($0).then(r => r.json())")>]
-let fetchJson (url: string) : JS.Promise<obj> = jsNative
-
-// 動的スクリプト読み込み - 重複読み込み防止バージョン＋デバッグ強化
-[<Emit("""
-new Promise((resolve, reject) => { 
-    const selector = `script[src='${$0}']`;
-    if (document.querySelector(selector)) { 
-        console.log('Script already loaded: ' + $0); 
-        resolve(); 
-        return; 
-    } 
-    const script = document.createElement('script'); 
-    script.src = $0; 
-    
-    script.onload = () => {
-        console.log('Successfully loaded script: ' + $0);
-        resolve();
-    }; 
-    
-    script.onerror = (error) => {
-        console.error('Failed to load script: ' + $0, error);
-        reject(new Error('Failed to load script: ' + $0));
-    }; 
-    
-    document.head.appendChild(script);
-    console.log('Appended script to head: ' + $0);
-})
-""")>]
-let loadScript (url: string) : JS.Promise<unit> = jsNative
-
-// HTMLからプラグインスクリプトを自動的に読み込む
-[<Emit("""
-new Promise((resolve, reject) => {
-    try {
-        const pluginScripts = document.querySelectorAll('script[type="plugin"]');
-        console.log('Found ' + pluginScripts.length + ' plugin scripts');
-        
-        if (pluginScripts.length === 0) {
-            resolve();
-            return;
-        }
-        
-        const promises = [];
-        
-        for (const script of pluginScripts) {
-            const src = script.getAttribute('src');
-            if (src) {
-                console.log('Loading plugin script: ' + src);
-                promises.push(new Promise((innerResolve, innerReject) => {
-                    const scriptEl = document.createElement('script');
-                    scriptEl.src = src;
-                    scriptEl.onload = innerResolve;
-                    scriptEl.onerror = innerReject;
-                    document.head.appendChild(scriptEl);
-                }));
-            }
-        }
-        
-        Promise.all(promises).then(resolve).catch(reject);
-    } catch (error) {
-        console.error('Error loading plugin scripts:', error);
-        reject(error);
-    }
-})
-""")>]
-let loadPluginScriptTags () : JS.Promise<unit> = jsNative
+open App.JsUtils
 
 // プラグインヘルパーライブラリを読み込む
 let loadPluginHelpers () =

--- a/src/PluginSystem.fs
+++ b/src/PluginSystem.fs
@@ -37,10 +37,6 @@ let logPluginError (pluginId: string) (operation: string) (ex: exn) =
     printfn "Stack trace: %s" ex.StackTrace
 // より高度なロギングやテレメトリを実装可能
 
-// F#側のプラグインディスパッチ関数をグローバルに公開
-[<Emit("window.appPluginDispatch = $0")>]
-let exposePluginDispatch (dispatch: obj -> unit) : unit = jsNative
-
 // プラグイン登録関数
 let registerPlugin (plugin: RegisteredPlugin) (dispatch: (Msg -> unit) option) =
     // バージョン互換性チェック
@@ -244,18 +240,6 @@ let getAvailableCustomTabs () =
     |> Seq.distinct
     |> Seq.map CustomTab
     |> Seq.toList
-
-// グローバルなJavaScriptブリッジ関数を使用して更新関数を呼び出す
-[<Emit("window.FSharpJsBridge.callUpdateHandler($0, $1, $2)")>]
-let callUpdateHandlerViaJsBridge (updateFn: obj) (payload: obj) (model: obj) : obj = jsNative
-
-// 統合されたupdate関数を呼び出す
-[<Emit("window.FSharpJsBridge.callUnifiedUpdateHandler($0, $1, $2, $3)")>]
-let callUnifiedUpdateHandler (updateFn: obj) (messageType: string) (payload: obj) (model: obj) : obj = jsNative
-
-// デバッグ用のオブジェクトロギング関数
-[<Emit("window.FSharpJsBridge.logObject($0, $1)")>]
-let logObjectViaJsBridge (label: string) (obj: obj) : obj = jsNative
 
 let applyCustomUpdates (msgType: string) (payload: obj) (model: obj) : obj =
     printfn "Applying custom updates for message type: %s" msgType

--- a/src/Subscription.fs
+++ b/src/Subscription.fs
@@ -1,28 +1,10 @@
 // Subscription.fs - レガシーコード削除版
 module App.Subscription
 
-open Fable.Core
 open App.Types
 open App.JsUtils
 open App.PluginLoader
 open App.Plugins
-
-// Store the registerPluginFromJs function directly in a global variable
-[<Emit("window._fsharpRegisterPluginFn = $0")>]
-let storeRegisterPluginFunction (fn: obj -> (Msg -> unit) option -> bool) : unit = jsNative
-
-// Set up the global registration function that will call our stored function
-[<Emit("""
-window.registerFSharpPlugin = function(plugin) {
-    try {
-        return window._fsharpRegisterPluginFn(plugin);
-    } catch (error) {
-        console.error("Error registering plugin:", error);
-        return false;
-    }
-}
-""")>]
-let setupGlobalRegistration () : unit = jsNative
 
 // プラグインローダーサブスクリプション
 let pluginLoader =

--- a/src/doc/TODO.md
+++ b/src/doc/TODO.md
@@ -6,5 +6,5 @@
 - ~~StyleはTailwind CSSを使う。styles.cssはすでに作成済み~~
 - プラグインのローディングメッセージにエラーを使うべきではない。情報メッセージや警告メッセージも用意すべき
 - プラグインのview関数を判別共用体に対応させて配列に変更した。update関数も合わせるべき。
-- Emitカスタム属性を使ってJavaScriptとの相互運用を行っている関数はJsUtils.fsにまとめる
+- ~~Emitカスタム属性を使ってJavaScriptとの相互運用を行っている関数はJsUtils.fsにまとめる~~
 - src\Subscription.fsのpluginLoaderのMsg->JavaScript変換は共通関数に置き換える


### PR DESCRIPTION
# JavaScript相互運用関数の整理

## 概要
JavaScript相互運用に関わる関数、特に[<Emit>]属性を使用している関数をJsUtils.fsに集約し、コードの整理と重複排除を行いました。

## 変更内容
- JsUtils.fsにJavaScript相互運用関数を機能別にセクション分けして集約
- PluginLoader.fs、Subscription.fs、PluginSystem.fs、Interop.fsから重複関数を削除
- 各ファイルからJsUtils.fsの関数を参照するように更新

## 効果
- 相互運用コードの保守性が向上
- 関数定義の重複が解消され、コードベースがスリムに
- JavaScript連携の命名と使用方法が一貫化

## テスト
- 各機能が以前と同様に動作することを確認済み
- プラグインの読み込みとメッセージ処理が正常に機能

今後、新しいJavaScript相互運用関数を追加する場合は、JsUtils.fsに集約することで一貫性を維持できます。